### PR TITLE
Cleanup rack form_hash in env variable

### DIFF
--- a/lib/grape/batch/request.rb
+++ b/lib/grape/batch/request.rb
@@ -34,6 +34,7 @@ module Grape
         @env['PATH_INFO'] = path
         @env['QUERY_STRING'] = query_string
         @env['rack.input'] = rack_input
+        @env.delete('rack.request.form_hash') if @env.has_key? 'rack.request.form_hash'
         @env
       end
     end


### PR DESCRIPTION
If you have batch 2 POST requests, e.g.
`
{
    "requests": [
        {
            "method": "POST",
            "path": "/api/v1/results",
            "body": {
            	"c": 0
            }
        },
        {
            "method": "POST",
            "path": "/api/v1/results",
            "body": {
            	"a": 2,
            	"b":1
            }
        }
    ]
}
`
the second request executed in grape will get *merged* POST parameters

`
{
            	"c": 0,
    "a": 2,
            	"b":1
            }
`
because grape merges existing rack.form_hash from env, see https://github.com/ruby-grape/grape/blob/master/lib/grape/middleware/formatter.rb line 105

To fix that we need to cleanup env variable 'rack.request.form_hash'